### PR TITLE
Set state prior to changing room

### DIFF
--- a/src/js/components/Lobby.js
+++ b/src/js/components/Lobby.js
@@ -91,10 +91,14 @@ export default class Lobby extends React.Component {
         }
     }
 
+    componentWillReceiveProps(nextProps) {
+        if ((this.props.room !== nextProps.room) && this.state.showPlaygroundGeometry) {
+            this.setState({showPlaygroundGeometry: false});
+        }
+    }
+
     componentDidUpdate(prevProps, prevState) {
         if (prevProps.room !== 'lobby' && this.props.room === 'lobby') {
-            this.setState({showPlaygroundGeometry: false});
-
             // Navigation UI toggle
             this.refs['navigationSphere'].removeEventListener('click', this.navigateToLobby);
             this.refs['navigationSphere'].addEventListener('click', this.togglePlaygroundGeometry);


### PR DESCRIPTION
This fixes the "Cannot read property 'dispose' of undefined" bug when switching back from VC to lobby.