### PR TITLE
Bump matrix-js-sdk to pull in default to VP8

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "babel-polyfill": "^6.23.0",
     "headtrackr": "0.0.1",
     "lodash": "^4.17.4",
-    "matrix-js-sdk": "matrix-org/matrix-js-sdk#525fe24328a397f578a2d5888e54dfb03e8cb309",
+    "matrix-js-sdk": "matrix-org/matrix-js-sdk#65852f5f6654815702ae863dab464e91db3d48c8",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-loader": "^2.4.0",


### PR DESCRIPTION
Also we can now add the following as the third argument of the
createNewMatrixCall call to enable H.264:

{ codecPriority: ['H264'] }